### PR TITLE
Fix keyboard change listener bug

### DIFF
--- a/tedkeyboardobserver/src/main/java/gun0912/tedkeyboardobserver/BaseKeyboardObserver.kt
+++ b/tedkeyboardobserver/src/main/java/gun0912/tedkeyboardobserver/BaseKeyboardObserver.kt
@@ -2,6 +2,7 @@ package gun0912.tedkeyboardobserver
 
 import android.app.Activity
 import android.graphics.Rect
+import android.util.DisplayMetrics
 import android.view.ViewTreeObserver
 
 abstract class BaseKeyboardObserver(private val activity: Activity) {
@@ -13,7 +14,20 @@ abstract class BaseKeyboardObserver(private val activity: Activity) {
 
     private var lastVisibleDecorViewHeight = 0
 
-    private var minKeyboardHeightPx = 0
+    private val softKeyButtonHeight = {
+        val displayMetrics = DisplayMetrics()
+        activity.windowManager.defaultDisplay.getMetrics(displayMetrics)
+        val usableHeight = displayMetrics.heightPixels
+        activity.windowManager.defaultDisplay.getRealMetrics(displayMetrics)
+        val realHeight = displayMetrics.heightPixels
+        if (realHeight > usableHeight)
+            realHeight - usableHeight
+        else
+            0
+    }()
+
+    private var minKeyboardHeightPx = softKeyButtonHeight
+
 
     private lateinit var onKeyboardListener: OnKeyboardListener
 
@@ -40,7 +54,7 @@ abstract class BaseKeyboardObserver(private val activity: Activity) {
             if (lastVisibleDecorViewHeight > visibleDecorViewHeight + minKeyboardHeightPx) {
                 // Notify listener about keyboard being shown.
                 minKeyboardHeightPx =
-                    ((lastVisibleDecorViewHeight - visibleDecorViewHeight) * 0.9).toInt()
+                    ((lastVisibleDecorViewHeight - visibleDecorViewHeight) * 0.9).toInt() - softKeyButtonHeight
                 onKeyboardListener.onKeyboardChange(true)
             } else if (lastVisibleDecorViewHeight + minKeyboardHeightPx < visibleDecorViewHeight) {
                 // Notify listener about keyboard being hidden.


### PR DESCRIPTION
### **버그**
- originalWindowHeight != currentWindowHeight 값은 하단 SoftKeyButton의 show/hide으로 달라 질 수 있어서 실제로 키보드가 show/hide 됐다고 보기 힘들다고 생각합니다.

### **수정**
- softKeyButton의 Height를 구하고 이를 키보드 Height의 초기값으로 넣어줘서 SoftKeyButton의 show/hide로 인한 이벤트를 무시하게 만듭니다.
- 화면에 키보드가 보여 질 때 화면 Height 값의 변화를 구해서 90%의 값에 SoftKeyButton의 Height를 뺀 값을 구한 다음 추후에 사용하도록 해서 실제 키보드가 show/hide 될 때 이벤트가 발생 하도록 변경 했습니다.
- SoftKeyButton이 hide인 상황에서 키보드가 올라오면 SoftKeyButton도 같이 보이면서 Keyboard의 Height가 SoftKeyButton의 크기까지 포함이 되고 SoftKeyButton이 hide에서 show인 상황으로 전환시에 동작을 하지 않기 때문에 SoftKeyButton의 Height를 뺐습니다.